### PR TITLE
feat: limiter le nombre de centres à 20

### DIFF
--- a/content_scripts/doctolib/search.js
+++ b/content_scripts/doctolib/search.js
@@ -65,6 +65,13 @@
     if (locations[locationUrl]) {
       delete locations[locationUrl];
     } else {
+      if (Object.keys(locations).length >= 20) {
+        alert(
+          "Pour ne pas trop charger les serveurs de Doctolib, il n'est pas possible de surveiller plus de 20 centres en même temps. Supprimez des centres de votre liste pour en ajouter d'autres."
+        );
+        return;
+      }
+
       locations[locationUrl] = {
         name: this.dataset.locationName,
         img: this.dataset.locationImg,


### PR DESCRIPTION
Je pense qu'il faut limiter le nombre de centres à surveiller à 20 pour : 

1. ne pas trop charger les serveurs de Doctolib
2. éviter les erreurs dues à un trop grand nombre de requêtes en parallèle
3. ne pas dépasser la place disponible dans `local.sync`

Close #8.