### PR TITLE
feat: Use fireFullClick for the modal confirmation

### DIFF
--- a/content_scripts/doctolib/book.js
+++ b/content_scripts/doctolib/book.js
@@ -204,11 +204,7 @@
       }
 
       // Bouton de confirmation de la popup
-      document
-        .querySelector(".dl-modal-footer .dl-button-label")
-        .dispatchEvent(
-          new MouseEvent("mouseup", { bubbles: true, cancelable: true })
-        );
+      fireFullClick(document.querySelector(".dl-modal-footer .dl-button-label"));
       await wait();
 
       // Pour qui prenez-vous ce rendez-vous ? (moi)


### PR DESCRIPTION
J'ai essayé de faire une réservation jusqu'au bout, et j'ai remarqué que, manuellement du moins, la modale n'était pas "acceptée" avec juste le mouseup, il faut un mousedown suivi d'un mouseup. Donc j'ai utilisé fireFullClick comme on en avait parlé dans une autre PR.
J'ai vérifié manuellement avec la même fonction fireFullClick dans la web console sur une vraie modale de réservation, mais je n'ai pas testé de bout en bout en utilisant l'extension.