### PR TITLE
fix: Correction de quelques problèmes

### DIFF
--- a/content_scripts/doctolib/book.js
+++ b/content_scripts/doctolib/book.js
@@ -100,6 +100,7 @@
     // * "Patients de moins de 50 ans"
     // * "Grand public"
     // * "Patient de plus de 18 ans" (Centre de Nogent-sur-Marne)
+    // * "Personnes de plus de 12 ans" (CHU de Caen)
     //
     // Ne doit pas matcher :
     // * "plus de 18 ans avec comorbidité"
@@ -108,7 +109,7 @@
     //
     // Oui, ça mériterait un test unitaire !
     return (
-      /(?:18 à|plus de 18|particulier|éligibles|moins (?:de )?50|public)/i.test(
+      /(?:18 à|plus de (?:12|18)|particulier|éligibles|moins (?:de )?50|public)/i.test(
         text
       ) &&
       !text.includes("comorb") &&

--- a/content_scripts/doctolib/book.js
+++ b/content_scripts/doctolib/book.js
@@ -359,12 +359,27 @@
         await waitForElementToBeRemoved(overlay);
       }
 
-      const slot2 = await getAvailableSlot();
-      if (slot2) {
-        slot2.click();
-      } else {
-        throw new Error("Pas de créneau trouvé pour le second rendez-vous.");
+      let slot2 = await getAvailableSlot();
+      if (slot2 === null) {
+        // Dans de rares cas, il faut cliquer sur "Prochain RDV" aussi pour le
+        // second rendez-vous
+        const $nextAvailabilities = await waitForSelector(
+          ".availabilities-next-slot button"
+        );
+        if (!$nextAvailabilities)
+          throw new Error(
+            "Aucun créneau disponible pour le second rendez-vous 1"
+          );
+        $nextAvailabilities.click();
+
+        slot2 = await getAvailableSlot();
+        if (slot2 === null)
+          throw new Error(
+            "Aucun créneau disponible pour le second rendez-vous 2"
+          );
       }
+
+      slot2.click();
 
       // Boutons "J'accepte" dans la popup "À lire avant de prendre un rendez-vous"
       let el;

--- a/content_scripts/doctolib/book.js
+++ b/content_scripts/doctolib/book.js
@@ -101,6 +101,7 @@
     // * "Grand public"
     // * "Patient de plus de 18 ans" (Centre de Nogent-sur-Marne)
     // * "Personnes de plus de 12 ans" (CHU de Caen)
+    // * "Personnes de 18 ans et plus" (GH Saint-Vincent de Strasbourg)
     //
     // Ne doit pas matcher :
     // * "plus de 18 ans avec comorbidité"
@@ -109,7 +110,7 @@
     //
     // Oui, ça mériterait un test unitaire !
     return (
-      /(?:18 à|plus de (?:12|18)|particulier|éligibles|moins (?:de )?50|public)/i.test(
+      /(?:18 à|plus de (?:12|18)|18 ans et plus|particulier|éligibles|moins (?:de )?50|public)/i.test(
         text
       ) &&
       !text.includes("comorb") &&

--- a/content_scripts/doctolib/book.js
+++ b/content_scripts/doctolib/book.js
@@ -86,7 +86,8 @@
       !(
         (text.startsWith("2") || text.startsWith("3")) // La deuxième et la troisième dose doivent être exclue (ex : https://www.doctolib.fr/vaccination-covid-19/lille/centre-de-vaccination-covid-19-centre-de-vaccination-covid-19-zenith-de-lille?highlight%5Bspeciality_ids%5D%5B%5D=5494)
       ) &&
-      !text.includes("unique") // On ne veut pas sélectionner l'injection unique mais la double injection (ex: https://www.doctolib.fr/vaccination-covid-19/lyon/vaccinationhcl?highlight%5Bspeciality_ids%5D%5B%5D=5494&pid=practice-163796)
+      !text.includes("unique") && // On ne veut pas sélectionner l'injection unique mais la double injection (ex: https://www.doctolib.fr/vaccination-covid-19/lyon/vaccinationhcl?highlight%5Bspeciality_ids%5D%5B%5D=5494&pid=practice-163796)
+      !text.includes("sans rappel") // idem (ex: https://www.doctolib.fr/pharmacie/savigneux/pharmacie-de-savigneux, https://www.doctolib.fr/vaccination-covid-19/montbrison/centre-de-vaccination-covid-ville-de-montbrison?highlight%5Bspeciality_ids%5D%5B%5D=5494)
     );
   }
 
@@ -182,7 +183,10 @@
         let optionFound = false;
         for (const $option of $bookingSpecialty.querySelectorAll("option")) {
           options.push($option.textContent);
-          if (!/vaccination/i.test($option.textContent)) continue;
+          // Voir
+          // https://www.doctolib.fr/pharmacie/savigneux/pharmacie-de-savigneux
+          // pour "Pharmacien".
+          if (!/vaccination|pharmacien/i.test($option.textContent)) continue;
           selectOption($bookingSpecialty, $option);
           optionFound = true;
           wait = true;


### PR DESCRIPTION
Ce PR corrige quelques problèmes:
* des types de rendez-vous nouveaux (avec/sans rappel)
* des motifs nouveaux (par exemple #79 mais pas que)
* le fait que parfois la page "calendrier" pour le second rendez-vous est vide, et donc il faut cliquer sur le bouton pour afficher une seconde page. On avait déjà la logique pour le premier rendez-vous donc j'ai simplement copié-collé sans chercher particulièrement à factoriser (à la fois par flemmardise (j'avoue) et aussi car je ne voulais pas casser ce qui marchait)
* je me suis rendu compte qu'on arrivait pas toujours à obtenir le bon element HTML pour le slot du second rendez-vous car les slots du premier rendez-vous étaient encore affichés. Cela me semble une race assez fréquente mais curieusement on ne l'a pas vu avant, et je ne l'ai vue que ce soir. J'ai corrigé en attendant la disparition de l'overlay de chargement.

J'ai pas mal testé donc si personne ne review d'ici demain je vais merger pour que @dunglas puisse faire une release.