### PR TITLE
feat: add support for first, second, and third injection independently

### DIFF
--- a/browser_action/index.html
+++ b/browser_action/index.html
@@ -96,6 +96,29 @@
         <summary>Options avancées</summary>
 
         <div class="panel-formElements-item">
+          <div>
+            <input
+              type="radio"
+              name="injectionType"
+              id="fullServiceInjection"
+              checked
+            />
+            <label for="fullServiceInjection">1ère dose (avec rappel)</label>
+          </div>
+          <div>
+            <input type="radio" name="injectionType" id="firstInjectionOnly" />
+            <label for="firstInjectionOnly">1ère dose (sans rappel)</label>
+          </div>
+          <div>
+            <input type="radio" name="injectionType" id="secondInjectionOnly" />
+            <label for="secondInjectionOnly">2ème dose</label>
+          </div>
+          <div>
+            <input type="radio" name="injectionType" id="thirdInjectionOnly" />
+            <label for="thirdInjectionOnly">3ème dose</label>
+          </div>
+        </div>
+        <div class="panel-formElements-item">
           <button id="reset" class="expander">
             Remise à zéro (effacera toutes les données)
           </button>

--- a/browser_action/index.js
+++ b/browser_action/index.js
@@ -83,6 +83,11 @@
     ).checked = true;
   }
 
+  /** @param {'fullServiceInjection' | 'firstInjectionOnly' | 'secondInjectionOnly' | 'thirdInjectionOnly'} injectionType Le type d'injection souhaité par le user */
+  function displayInjectionType(injectionType) {
+    document.getElementById(injectionType).checked = true;
+  }
+
   // Preparation des données
   const appStatus = new AppStatus();
   const vCLStorage = new VCLocalStorage({
@@ -95,6 +100,7 @@
   appStatus.onLocationChange(displayLocations, displayLocations);
   appStatus.onStoppedChange(displayStopStart);
   appStatus.onAutoBookChange(displayAutoBook);
+  appStatus.onInjectionTypeChange(displayInjectionType);
 
   // Initialisation donnée
   appStatus.init();
@@ -114,6 +120,15 @@
   document.getElementById("enableAutoBook").onclick =
     appStatus.setAutoBook.bind(appStatus, true);
 
+  document.getElementById("fullServiceInjection").onclick =
+    appStatus.setInjectionType.bind(appStatus, "fullServiceInjection");
+  document.getElementById("firstInjectionOnly").onclick =
+    appStatus.setInjectionType.bind(appStatus, "firstInjectionOnly");
+  document.getElementById("secondInjectionOnly").onclick =
+    appStatus.setInjectionType.bind(appStatus, "secondInjectionOnly");
+  document.getElementById("thirdInjectionOnly").onclick =
+    appStatus.setInjectionType.bind(appStatus, "thirdInjectionOnly");
+
   document.getElementById("reset").onclick = () => {
     if (
       !confirm(
@@ -129,5 +144,6 @@
   // Affichage
   displayStopStart(appStatus.getStopped());
   displayAutoBook(appStatus.getAutoBook());
+  displayInjectionType(appStatus.getInjectionType());
   displayLocations();
 })();

--- a/commons/AppStatus.js
+++ b/commons/AppStatus.js
@@ -38,6 +38,7 @@ class AppStatus {
     const result = await browser.storage.sync.get({
       locations: {},
       stopped: false,
+      autoBook: false,
     });
 
     Object.keys(result.locations).forEach((url) => {

--- a/commons/AppStatus.js
+++ b/commons/AppStatus.js
@@ -18,6 +18,8 @@ class AppStatus {
     this.stopped = false;
     /** @type {boolean} est-ce qu'on souhaite réserver le créneau pour le user ? */
     this.autoBook = false;
+    /** @type {'fullServiceInjection' | 'firstInjectionOnly' | 'secondInjectionOnly' | 'thirdInjectionOnly'} type d'injection souhaité par le user */
+    this.injectionType = "fullServiceInjection";
     /** @type {(string) => void} callback quand une {@link VaccineLocation} a été ajouté */
     this.onLocationAddedCb = (job) => {};
     /** @type {(string) => void} callback quand une {@link VaccineLocation} a été supprimée */
@@ -26,6 +28,8 @@ class AppStatus {
     this.onStoppedChangeCb = (newValue) => {};
     /** @type {(boolean) => void} callback quand autoBook change de valeur */
     this.onAutoBookChangeCb = (newValue) => {};
+    /** @type {('fullServiceInjection' | 'firstInjectionOnly' | 'secondInjectionOnly' | 'thirdInjectionOnly') => void} callback quand injectionType change de valeur */
+    this.onInjectionTypeCb = (newValue) => {};
 
     this.onStorageChange = this.onStorageChange.bind(this);
     browser.storage.onChanged.addListener(this.onStorageChange);
@@ -39,6 +43,7 @@ class AppStatus {
       locations: {},
       stopped: false,
       autoBook: false,
+      injectionType: "fullServiceInjection",
     });
 
     Object.keys(result.locations).forEach((url) => {
@@ -51,6 +56,9 @@ class AppStatus {
 
     this.autoBook = result.autoBook === true;
     this.onAutoBookChangeCb(this.autoBook);
+
+    this.injectionType = result.injectionType;
+    this.onInjectionTypeCb(this.injectionType);
   }
 
   getLocations() {
@@ -81,6 +89,10 @@ class AppStatus {
     return this.autoBook;
   }
 
+  getInjectionType() {
+    return this.injectionType;
+  }
+
   /**
    * @param {(string) => void} cbAdd callback quand une {@link VaccineLocation} a été ajouté
    * @param {(string) => void} cbDelete callback quand une {@link VaccineLocation} a été supprimée
@@ -104,6 +116,13 @@ class AppStatus {
     this.onAutoBookChangeCb = callback;
   }
 
+  /**
+   * @param {('fullServiceInjection' | 'firstInjectionOnly' | 'secondInjectionOnly' | 'thirdInjectionOnly') => void} callback quand injectionType change de valeur
+   */
+  onInjectionTypeChange(callback) {
+    this.onInjectionTypeCb = callback;
+  }
+
   start() {
     this.stopped = false;
     browser.storage.sync.set({ stopped: this.stopped });
@@ -123,6 +142,14 @@ class AppStatus {
   }
 
   /**
+   * @param {'fullServiceInjection' | 'firstInjectionOnly' | 'secondInjectionOnly' | 'thirdInjectionOnly'} value The new injectionType value
+   */
+  setInjectionType(value) {
+    this.injectionType = value;
+    browser.storage.sync.set({ injectionType: this.injectionType });
+  }
+
+  /**
    * Gérer le clean complet du stockage de l'application
    */
   clear() {
@@ -135,6 +162,8 @@ class AppStatus {
     this.onStoppedChangeCb(this.stopped);
     this.autoBook = false;
     this.onAutoBookChangeCb(this.autoBook);
+    this.injectionType = "fullServiceInjection";
+    this.onInjectionTypeCb(this.injectionType);
   }
 
   /**
@@ -149,6 +178,7 @@ class AppStatus {
     this.onLocationDeletedCb = null;
     this.onStoppedChangeCb = null;
     this.onAutoBookChangeCb = null;
+    this.onInjectionTypeCb = null;
   }
 
   /**
@@ -189,6 +219,12 @@ class AppStatus {
       this.autoBook = change.autoBook.newValue === true;
 
       this.onAutoBookChangeCb(this.autoBook);
+    }
+
+    if (change.injectionType) {
+      this.injectionType = change.injectionType.newValue;
+
+      this.onInjectionTypeCb(this.injectionType);
     }
   }
 }

--- a/content_scripts/doctolib/book.js
+++ b/content_scripts/doctolib/book.js
@@ -384,7 +384,13 @@
       // Boutons "J'accepte" dans la popup "À lire avant de prendre un rendez-vous"
       let el;
       while (
-        (el = await waitForSelector(".dl-button-check-inner:not([disabled])"))
+        (el = await waitForSelector(
+          ".dl-button-check-inner:not([disabled])"
+        )) ||
+        // Bouton radio "J'ai 18 ans ou plus", dernièr élément qui nécessite un traitement spécial avant l'apparition du bouton de confirmation
+        (el = await waitForSelector(
+          ".dl-appointment-rule-radio-group .dl-radio-button-label:nth-child(2) input:not(:checked)"
+        ))
       ) {
         el.click();
       }

--- a/content_scripts/doctolib/book.js
+++ b/content_scripts/doctolib/book.js
@@ -407,6 +407,10 @@
 
       fireFullClick(popupConfirmation);
 
+      // Ici la page entière recharge et le script ne peut pas continuer avec le choix du patient
+      // TODO: fix issue #70 see PR #81 for more information
+      throw new Error("Confirmation manuelle du RDV nécessaire");
+
       // Pour qui prenez-vous ce rendez-vous ? (moi)
       const masterPatientId = await waitForSelector(
         'input[name="masterPatientId"]'


### PR DESCRIPTION
The first and the second commit could be cherry-picked individually, as they are only bug fixes of the existing code.

- 9a7b22c: fixes a bug where the `autoBook` status was not correctly read from the storage
- 787ff96: fixes a bug where the automatic booking was no longer possible, due to an additional radio button in the confirmation popup
- 5f4f17c: adds an advanced option for those who wish to choose single injections