### PR TITLE
fix: doctolib.de shows in some cases the wrong text on the buttons in the search results

### DIFF
--- a/content_scripts/doctolib/search.js
+++ b/content_scripts/doctolib/search.js
@@ -60,6 +60,31 @@
     $el
       .querySelector(".dl-search-result-presentation > div:last-child")
       .insertAdjacentElement("beforebegin", $div);
+
+    // Callback function to execute when mutations on the href attribute are observed
+    const callback = (mutationsList, observer) => {
+      for (const mutation of mutationsList) {
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName === "href"
+        ) {
+          // Stop observing, we are re-rendering the button here
+          observer.disconnect();
+          $btn.remove();
+          addButton($el, locations);
+        }
+      }
+    };
+
+    // Create an observer instance linked to the callback function
+    const observer = new MutationObserver(callback);
+
+    // Start observing the a element for href changes
+    observer.observe($a, {
+      attributes: true,
+      childList: false,
+      subtree: false,
+    });
   }
 
   async function toggleLocation(locations) {

--- a/content_scripts/doctolib/search.js
+++ b/content_scripts/doctolib/search.js
@@ -8,8 +8,12 @@
   const MSG_DELETE = " Retirer de ma liste";
   const ICON_URL = browser.runtime.getURL("icons/vaccine-color.svg");
   const MAX_LOCATIONS = 24; // Limite de storage.sync
+  let observerList = [];
 
   function addButtons(locations) {
+    observerList.forEach((observer) => observer.disconnect());
+    observerList = [];
+
     document
       .querySelectorAll(".div-vaccin-click")
       .forEach(($el) => $el.remove());
@@ -61,8 +65,8 @@
       .querySelector(".dl-search-result-presentation > div:last-child")
       .insertAdjacentElement("beforebegin", $div);
 
-    // Callback function to execute when mutations on the href attribute are observed
-    const callback = (mutationsList, observer) => {
+    // Create an observer instance that watches for changes in the href attribute
+    const observer = new MutationObserver((mutationsList, observer) => {
       for (const mutation of mutationsList) {
         if (
           mutation.type === "attributes" &&
@@ -74,10 +78,9 @@
           addButton($el, locations);
         }
       }
-    };
+    });
 
-    // Create an observer instance linked to the callback function
-    const observer = new MutationObserver(callback);
+    observerList.push(observer);
 
     // Start observing the a element for href changes
     observer.observe($a, {


### PR DESCRIPTION
This is a very specific bug that occurs on doctolib.de only. In Germany, there are 2 types of insurances, the public, and private ones. Some doctors only take private patients. To pre-select the correct insurance type, doctolib updates asynchronously the URL params, after the initial page reload and the initial rendering of the firefox extension buttons.

This can lead to a bug where the button still shows `Ajouter à la liste` but should show `Retirer de la liste` instead.

This commit adds observers to the `href` attributes and triggers a re-render whenever they change.