### PR TITLE
ci: treat warnings as errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
 
 jobs:
-  prettier:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: Lint the web extension
-        run: npx web-ext lint
+        run: npx web-ext lint -w
 
       - name: Check CS
         run: npx prettier --check .


### PR DESCRIPTION
To catch problems such as https://github.com/dunglas/vaccin.click/pull/94 earlier.